### PR TITLE
fix(frontend): remove unused cn() helper (utils.ts)

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
## Summary

Removes `frontend/src/lib/utils.ts` which exports `cn()` — a Tailwind class merger with no call sites in the codebase.

## Changes

- Deleted `frontend/src/lib/utils.ts` (6 lines)
- The `cn()` function was the only export and was never imported/used
- Complementary to PR #10 which removes `react.svg` and unused imports

## Addresses

Issue #8: Remove unused frontend leftovers after lint/typecheck setup

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅

Note: `clsx` and `tailwind-merge` remain in package.json dependencies as removing unused npm packages is a separate concern from issue #8 scope.
